### PR TITLE
Update jdbc and allow namespaced keywords

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/java.jdbc "0.5.0"]
+                 [org.clojure/java.jdbc "0.6.2-alpha3"]
                  [org.clojure/core.async "0.2.385"]]
   ;:pedantic? :abort
   :scm {:name "git"

--- a/src/jeesql/core.clj
+++ b/src/jeesql/core.clj
@@ -2,7 +2,8 @@
   (:require [jeesql.util :refer [resource-file-url slurp-from-classpath]]
             [jeesql.generate :refer [generate-var]]
             [jeesql.queryfile-parser :refer [parse-tagged-queries]]
-            [jeesql.autoreload :refer [autoreload]]))
+            [jeesql.autoreload :refer [autoreload]]
+            [clojure.string :as str]))
 
 (defn defqueries
   "Defines several query functions, as defined in the given SQL file.
@@ -31,7 +32,7 @@
     (throw (Exception. "Missing an :as or a :refer")))
   (let [current-ns (ns-name *ns*)
         ;; Keep this .sql file's defqueries in a predictable place:
-        target-ns (symbol (str "yesquire/" sql-file))]
+        target-ns (-> (str "jeesql/" sql-file) (str/replace  #"/" ".") symbol)]
     `(do
        (ns-unalias *ns* '~as)
        (create-ns '~target-ns)

--- a/src/jeesql/generate.clj
+++ b/src/jeesql/generate.clj
@@ -76,27 +76,27 @@
   (first (jdbc/execute! db sql-and-params)))
 
 (defn insert-handler
-  [db [statement & params]]
-  (jdbc/db-do-prepared-return-keys db statement params))
+  [db statement-and-params]
+  (jdbc/db-do-prepared-return-keys db statement-and-params))
 
 (defn insert-handler-return-keys
   [return-keys db [statement & params]]
   (with-open [ps (jdbc/prepare-statement (jdbc/get-connection db) statement
-                                         :return-keys return-keys)]
-    (jdbc/db-do-prepared-return-keys db ps params)))
+                                         {:return-keys return-keys})]
+    (jdbc/db-do-prepared-return-keys db (cons ps params))))
 
 (defn query-handler
   [row-fn db sql-and-params]
   (jdbc/query db sql-and-params
-              :identifiers lower-case
-              :row-fn row-fn
-              :result-set-fn doall))
+              {:identifiers lower-case
+               :row-fn row-fn
+               :result-set-fn doall}))
 
 (defn query-handler-single-value
   [db sql-and-params]
   (jdbc/query db sql-and-params
-              :row-fn (comp val first seq)
-              :result-set-fn first))
+              {:row-fn (comp val first seq)
+               :result-set-fn first}))
 
 (defn query-handler-stream
   [fetch-size row-fn db result-channel sql-and-params]

--- a/src/jeesql/statement_parser.clj
+++ b/src/jeesql/statement_parser.clj
@@ -8,7 +8,7 @@
 (def ^{:doc "Regular expression to split statement into three parts: before the first parameter,
 the parameter name and the rest of the statement. A parameter always starts with a single colon and
 may contain alphanumerics as well as '-', '_' and '?' characters."}
-  parameter #"(?s)(.*?[^:\\]):(\p{Alpha}[\p{Alnum}\_\-\?]*)(.*)")
+  parameter #"(?s)(.*?[^:\\]):(\p{Alpha}[\p{Alnum}\_\-\?\./]*)(.*)")
 
 (defn- replace-escaped-colon [string]
   (str/replace string #"\\:" ":"))

--- a/test/jeesql/core_test.clj
+++ b/test/jeesql/core_test.clj
@@ -83,6 +83,10 @@
 
 (expect var? #'combined/edge)
 
+(expect first (combined/edge jeesql.core-test/derby-db))
+
 (require-sql ["jeesql/sample_files/combined_file.sql" :refer [the-time]])
 
 (expect var? #'the-time)
+
+(expect first (the-time jeesql.core-test/derby-db))


### PR DESCRIPTION
Moi Tatu,

I'd prefer to use jeesql over yesql, but unfortunately it's incompatible with my current project. If you're willing to accept PR's, I've got a couple of useful-ish changes here:
- Update to the newest java.jdbc version
- Allow / and . in the query parser, so you can use namespaced keywords like :foobar.spec/session-date
- Require-sql used to generate unusable namespaces, now it should work properly

The require-sql bug affects upstream also, and that fix is a port from https://github.com/krisajenkins/yesql/pull/149. Upstream maintenance seems to be a bit slow at the moment. 
