### PR TITLE
Clarify return-keys documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ called, instead of a sequence of maps.
 ### return-keys
 
 Return keys (for insert) is a vector of strings for keys to return.
-This is mainly for Oracle users.
+This is mainly for Oracle users. Remember to use the postfix <! in the function name 
+as yesql uses this naming convention to identify it needs to return values
+from the insert.
 
 ```SQL
 -- name: insert-foo<!


### PR DESCRIPTION
Because the function needs to be specially named, I found it useful to include that information here even though normally the documentation only covers the differences to yesql.